### PR TITLE
fix: Resolve build error by adding SVG Webpack config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,14 @@ const nextConfig: NextConfig = {
   images: {
     domains: ['picsum.photos', 'images.unsplash.com'],
   },
+  webpack(config) {
+    config.module.rules.push({
+      test: /\.svg$/,
+      use: ['@svgr/webpack'],
+    });
+
+    return config;
+  },
   experimental: {
     turbo: {
       rules: {

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,16 +14,6 @@ const nextConfig: NextConfig = {
 
     return config;
   },
-  experimental: {
-    turbo: {
-      rules: {
-        '*.svg': {
-          loaders: ['@svgr/webpack'],
-          as: '*.js',
-        },
-      },
-    },
-  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## #️⃣ Related Issue

> closes #23 


## 📝 Description

#### SVG Webpack config 추가

SVG 파일을 직접 import하는 과정에서 React가 이를 object로 인식하는 문제가 발생하여 빌드가 실패하였는데, Webpack 설정에서 @svgr/webpack을 추가하여 SVG 파일을 React 컴포넌트처럼 사용할 수 있도록 수정하여 문제 해결


## 📷 Screenshot (Optional)

## 💬 Review Requirements (Optional)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
